### PR TITLE
removing percent encoding of a url before it is used as a file path

### DIFF
--- a/Sources/StaticServer/HTTPHandler.swift
+++ b/Sources/StaticServer/HTTPHandler.swift
@@ -117,7 +117,7 @@ final class HTTPHandler: ChannelInboundHandler {
                 return
             }
 
-            var path = htdocsPath + path
+            var path = htdocsPath + (path.removingPercentEncoding ?? "")
             var isDir: ObjCBool = false
 
             guard FileManager.default.fileExists(atPath: path, isDirectory: &isDir) else {


### PR DESCRIPTION
### bug fix:
1. Removing percent encoding of a url before it is used as a file path。A url which is "first-post%20copy" will be converted to "first-post copy"